### PR TITLE
fix Firefox repaint bug

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -78,16 +78,22 @@ function HomeTitleAndNavbar() {
     return (
         <div
             className="fade-in"
-            style={{ opacity: 1, color: titleColor }}
+            style={{ 
+                position: "absolute",
+                top: "0",
+                width: "100vw",
+                height: "100vh",
+                opacity: 1, 
+                color: titleColor,
+            }}
         >
             <div
                 style={{
-                    width: "100vw",
-                    height: "100vh",
+                    width: "100%",
+                    height: "100%",
                     display: "flex",
                     justifyContent: "center",
                     alignItems: "center",
-                    position: "absolute",
                     top: "0",
 
                     "--font-size": "12vw",


### PR DESCRIPTION
Et voilà.

Le problème vient du fait que la div la plus "haute", à savoir "div.fade-in" a une "bounding box" incohérente : 
- La bounding box calculée par le navigateur (chromium ou firefox) est entièrement hors champ.
- Mais le contenu de cette div, parce que positionnée en "absolute" est ramené dans le champ.
- Firefox se contente de la première constatation pour conclure qu'il n'y a pas à rafraîchir le dessin du contenu (puisque hors champ)
- Là ou Chrome a l'air de traiter le pb au cas par cas, le parent est hors champ ? Ok, mais l'enfant est-il aussi ? Non, alors repaint.

Pour corriger le mieux c'est encore d'avoir des "bouding boxes" cohérentes. 